### PR TITLE
Use $default-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ name: Generate Wiki Links
 on:
   push:
     branches:
-    - master
-    - main
+    - $default-branch
 jobs:
   generate-wiki-links:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gds-generate-wiki-links
 This action generates a wiki directory of deployed services in a GDS cluster
 
-# Example Usage
+## Example Usage
 
 ```yml
 name: Generate Wiki Links

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ name: Generate Wiki Links
 on:
   push:
     branches:
-    - $default-branch
+      - $default-branch
 jobs:
   generate-wiki-links:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Use `$default-branch` instead of guessing.

https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/